### PR TITLE
Refactor runtime validation to tolerate no target runtime

### DIFF
--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -69,13 +69,11 @@ def _validate_pipeline_runtime(primary_pipeline: dict, runtime: str) -> bool:
     Generic pipelines do not have a persisted runtime type, and can be run on any runtime
     Runtime specific pipeline have a runtime type, and con only be run on matching runtime
     """
-    is_valid = False
-    pipeline_runtime = primary_pipeline["app_data"].get("runtime")
-    if not pipeline_runtime:
-        is_valid = True
-    else:
-        if runtime and pipeline_runtime == runtime:
-            is_valid = True
+    is_valid = True
+    if runtime:  # Only perform validation if a target runtime has been specified
+        pipeline_runtime = primary_pipeline["app_data"].get("runtime")
+        if pipeline_runtime and pipeline_runtime != runtime:
+            is_valid = False
 
     return is_valid
 


### PR DESCRIPTION
This adjusts the runtime validation method to tolerate commands like `describe` that don't specify a target runtime during preprocessing.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
